### PR TITLE
Implemented the additional properties resolver

### DIFF
--- a/src/DependencyInjection/Compiler/AdditionalPropertiesResolverPass.php
+++ b/src/DependencyInjection/Compiler/AdditionalPropertiesResolverPass.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SimpleBus\RabbitMQBundleBridge\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class AdditionalPropertiesResolverPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $delegatingResolverId = 'simple_bus.rabbit_mq_bundle_bridge.delegating_additional_properties_resolver';
+        if (!($container->has($delegatingResolverId))) {
+            return;
+        }
+
+        $resolverReferences = new \SplPriorityQueue();
+
+        foreach ($container->findTaggedServiceIds('simple_bus.additional_properties_resolver') as $serviceId => $tags) {
+            foreach ($tags as $tagAttributes) {
+                $priority = isset($tagAttributes['priority']) ? $tagAttributes['priority'] : 0;
+                $resolverReferences->insert(new Reference($serviceId), $priority);
+            }
+        }
+
+        $delegatingCleaner = $container->findDefinition($delegatingResolverId);
+        $delegatingCleaner->replaceArgument(0, iterator_to_array($resolverReferences, false));
+    }
+}

--- a/src/DependencyInjection/SimpleBusRabbitMQBundleBridgeExtension.php
+++ b/src/DependencyInjection/SimpleBusRabbitMQBundleBridgeExtension.php
@@ -92,6 +92,8 @@ class SimpleBusRabbitMQBundleBridgeExtension extends ConfigurableExtension imple
             'simple_bus.rabbit_mq_bundle_bridge.routing.routing_key_resolver',
              $routingKeyResolverId
         );
+
+        $loader->load('properties.yml');
     }
 
     private function requireBundle($bundleName, ContainerBuilder $container)

--- a/src/RabbitMQPublisher.php
+++ b/src/RabbitMQPublisher.php
@@ -3,6 +3,7 @@
 namespace SimpleBus\RabbitMQBundleBridge;
 
 use OldSound\RabbitMqBundle\RabbitMq\Producer;
+use SimpleBus\Asynchronous\Properties\AdditionalPropertiesResolver;
 use SimpleBus\Asynchronous\Publisher\Publisher;
 use SimpleBus\Asynchronous\Routing\RoutingKeyResolver;
 use SimpleBus\Serialization\Envelope\Serializer\MessageInEnvelopSerializer;
@@ -24,14 +25,21 @@ class RabbitMQPublisher implements Publisher
      */
     private $routingKeyResolver;
 
+    /**
+     * @var AdditionalPropertiesResolver
+     */
+    private $additionalPropertiesResolver;
+
     public function __construct(
         MessageInEnvelopSerializer $messageSerializer,
         Producer $producer,
-        RoutingKeyResolver $routingKeyResolver
+        RoutingKeyResolver $routingKeyResolver,
+        AdditionalPropertiesResolver $additionalPropertiesResolver
     ) {
         $this->serializer = $messageSerializer;
         $this->producer = $producer;
         $this->routingKeyResolver = $routingKeyResolver;
+        $this->additionalPropertiesResolver = $additionalPropertiesResolver;
     }
 
     /**
@@ -43,7 +51,8 @@ class RabbitMQPublisher implements Publisher
     {
         $serializedMessage = $this->serializer->wrapAndSerialize($message);
         $routingKey = $this->routingKeyResolver->resolveRoutingKeyFor($message);
+        $additionalProperties = $this->additionalPropertiesResolver->resolveAdditionalPropertiesFor($message);
 
-        $this->producer->publish($serializedMessage, $routingKey);
+        $this->producer->publish($serializedMessage, $routingKey, $additionalProperties);
     }
 }

--- a/src/Resources/config/commands.yml
+++ b/src/Resources/config/commands.yml
@@ -7,6 +7,7 @@ services:
             # defined in this bundle's configuration
             - @simple_bus.rabbit_mq_bundle_bridge.command_producer
             - @simple_bus.rabbit_mq_bundle_bridge.routing.routing_key_resolver
+            - @simple_bus.rabbit_mq_bundle_bridge.delegating_additional_properties_resolver
 
     simple_bus.rabbit_mq_bundle_bridge.commands_consumer:
         class: SimpleBus\RabbitMQBundleBridge\RabbitMQMessageConsumer

--- a/src/Resources/config/events.yml
+++ b/src/Resources/config/events.yml
@@ -10,6 +10,7 @@ services:
             # defined in this bundle's configuration
             - @simple_bus.rabbit_mq_bundle_bridge.event_producer
             - @simple_bus.rabbit_mq_bundle_bridge.routing.routing_key_resolver
+            - @simple_bus.rabbit_mq_bundle_bridge.delegating_additional_properties_resolver
 
     simple_bus.rabbit_mq_bundle_bridge.events_consumer:
         class: SimpleBus\RabbitMQBundleBridge\RabbitMQMessageConsumer

--- a/src/Resources/config/properties.yml
+++ b/src/Resources/config/properties.yml
@@ -1,0 +1,6 @@
+services:
+    simple_bus.rabbit_mq_bundle_bridge.delegating_additional_properties_resolver:
+        class: SimpleBus\Asynchronous\Properties\DelegatingAdditionalPropertiesResolver
+        public: false
+        arguments:
+         - []

--- a/src/SimpleBusRabbitMQBundleBridgeBundle.php
+++ b/src/SimpleBusRabbitMQBundleBridgeBundle.php
@@ -2,7 +2,9 @@
 
 namespace SimpleBus\RabbitMQBundleBridge;
 
+use SimpleBus\RabbitMQBundleBridge\DependencyInjection\Compiler\AdditionalPropertiesResolverPass;
 use SimpleBus\RabbitMQBundleBridge\DependencyInjection\SimpleBusRabbitMQBundleBridgeExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class SimpleBusRabbitMQBundleBridgeBundle extends Bundle
@@ -10,5 +12,10 @@ class SimpleBusRabbitMQBundleBridgeBundle extends Bundle
     public function getContainerExtension()
     {
         return new SimpleBusRabbitMQBundleBridgeExtension('simple_bus_rabbit_mq_bundle_bridge');
+    }
+
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new AdditionalPropertiesResolverPass());
     }
 }

--- a/tests/DependencyInjection/Compiler/AdditionalPropertiesResolverPassTest.php
+++ b/tests/DependencyInjection/Compiler/AdditionalPropertiesResolverPassTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace SimpleBus\RabbitMQBundleBridge\Tests\DependencyInjection\Compiler;
+
+use SimpleBus\RabbitMQBundleBridge\DependencyInjection\Compiler\AdditionalPropertiesResolverPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class AdditionalPropertiesResolverPassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContainerBuilder
+     */
+    private $container;
+
+    /**
+     * @var Definition
+     */
+    private $delegatingDefinition;
+
+    protected function setUp()
+    {
+        $this->container = new ContainerBuilder();
+        $this->delegatingDefinition = new Definition('stdClass', array(array()));
+        $this->container->setDefinition('simple_bus.rabbit_mq_bundle_bridge.delegating_additional_properties_resolver', $this->delegatingDefinition);
+        $this->container->addCompilerPass(new AdditionalPropertiesResolverPass());
+    }
+
+    /**
+     * @test
+     * @group test
+     */
+    public function it_configures_a_chain_of_buses_according_to_the_given_priorities()
+    {
+        $this->createResolver('resolver100', 100);
+        $this->createResolver('resolver-100', -100);
+        $this->createResolver('resolver200', 200);
+
+        $this->container->compile();
+
+        $this->resolverContainsResolvers(array('resolver200', 'resolver100', 'resolver-100'));
+    }
+
+    private function createResolver($id, $priority)
+    {
+        $definition = new Definition('stdClass');
+        $definition->addTag('simple_bus.additional_properties_resolver', array('priority' => $priority));
+
+        $this->container->setDefinition($id, $definition);
+
+        return $definition;
+    }
+
+    private function resolverContainsResolvers($expectedResolverIds)
+    {
+        $actualResolverIds = [];
+
+        foreach ($this->delegatingDefinition->getArgument(0) as $argument) {
+            $this->assertInstanceOf(
+                'Symfony\Component\DependencyInjection\Reference',
+                $argument
+            );
+            $actualResolverIds[] = (string) $argument;
+        }
+
+        $this->assertEquals($expectedResolverIds, $actualResolverIds);
+    }
+}

--- a/tests/Functional/AdditionalPropertiesResolverArray.php
+++ b/tests/Functional/AdditionalPropertiesResolverArray.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SimpleBus\RabbitMQBundleBridge\Tests\Functional;
+
+use SimpleBus\Asynchronous\Properties\AdditionalPropertiesResolver;
+use SimpleBus\Message\Message;
+
+class AdditionalPropertiesResolverArray implements AdditionalPropertiesResolver
+{
+
+    /**
+     * @var array
+     */
+    private $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function resolveAdditionalPropertiesFor($message)
+    {
+        return $this->data;
+    }
+}

--- a/tests/Functional/AdditionalPropertiesResolverProducerMock.php
+++ b/tests/Functional/AdditionalPropertiesResolverProducerMock.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SimpleBus\RabbitMQBundleBridge\Tests\Functional;
+
+use OldSound\RabbitMqBundle\RabbitMq\Producer;
+
+class AdditionalPropertiesResolverProducerMock extends Producer
+{
+    /**
+     * @var array
+     */
+    private $additionalProperties;
+
+    public function getAdditionalProperties()
+    {
+        return $this->additionalProperties;
+    }
+
+    public function publish($msgBody, $routingKey = '', $additionalProperties = array())
+    {
+        $this->additionalProperties = $additionalProperties;
+    }
+}

--- a/tests/Functional/config.yml
+++ b/tests/Functional/config.yml
@@ -35,6 +35,20 @@ services:
         tags:
             - { name: asynchronous_command_handler, handles: SimpleBus\RabbitMQBundleBridge\Tests\Functional\AlwaysFailingCommand }
 
+    additional_properties_resolver:
+        class: SimpleBus\RabbitMQBundleBridge\Tests\Functional\AdditionalPropertiesResolverArray
+        arguments:
+            - { debug: string }
+        tags:
+            - { name: simple_bus.additional_properties_resolver }
+
+    simple_bus.rabbit_mq_bundle_bridge.delegating_additional_properties_resolver.public:
+        alias: simple_bus.rabbit_mq_bundle_bridge.delegating_additional_properties_resolver
+
+    simple_bus.rabbit_mq_bundle_bridge.delegating_additional_properties_resolver.producer_mock:
+        class: SimpleBus\RabbitMQBundleBridge\Tests\Functional\AdditionalPropertiesResolverProducerMock
+        arguments: [@old_sound_rabbit_mq.connection.default]
+
 old_sound_rabbit_mq:
     connections:
         default:

--- a/tests/RabbitMQPublisherTest.php
+++ b/tests/RabbitMQPublisherTest.php
@@ -29,7 +29,9 @@ class RabbitMQPublisherTest extends \PHPUnit_Framework_TestCase
 
         $routingKeyResolver = $this->routingKeyResolverStub($message, $routingKey);
 
-        $publisher = new RabbitMQPublisher($serializer, $producer, $routingKeyResolver);
+        $additionalPropertiesResolver = $this->additionalPropertiesResolverStub($message, []);
+
+        $publisher = new RabbitMQPublisher($serializer, $producer, $routingKeyResolver, $additionalPropertiesResolver);
 
         $publisher->publish($message);
     }
@@ -60,6 +62,18 @@ class RabbitMQPublisherTest extends \PHPUnit_Framework_TestCase
             ->method('resolveRoutingKeyFor')
             ->with($this->identicalTo($message))
             ->will($this->returnValue($routingKey));
+
+        return $resolver;
+    }
+
+    private function additionalPropertiesResolverStub($message, $additionalProperties)
+    {
+        $resolver = $this->getMock('SimpleBus\Asynchronous\Properties\AdditionalPropertiesResolver');
+        $resolver
+            ->expects($this->any())
+            ->method('resolveAdditionalPropertiesFor')
+            ->with($this->identicalTo($message))
+            ->will($this->returnValue($additionalProperties));
 
         return $resolver;
     }


### PR DESCRIPTION
RabbitMQ 3.5 has a method to send a message with different priority's. But currently we can't send additional properties to the consumer. This implements my pull request https://github.com/SimpleBus/Asynchronous/pull/2.

Our use case is that we have a CommandHandler which is generating video's from images. We have a cronjob that gets new images from different api's and from that it generates images. But sometimes a customer needs de latest video fast and with the priority option it can skip the line and proces faster. 

This pull request depends on https://github.com/SimpleBus/Asynchronous/pull/2
