### PR TITLE
Updates the return value to match with the OldSound bundle

### DIFF
--- a/src/RabbitMQMessageConsumer.php
+++ b/src/RabbitMQMessageConsumer.php
@@ -39,14 +39,14 @@ class RabbitMQMessageConsumer implements ConsumerInterface
                 new MessageConsumed($msg)
             );
 
-            return self::MSG_ACK;
+            return true;
         } catch (Exception $exception) {
             $this->eventDispatcher->dispatch(
                 Events::MESSAGE_CONSUMPTION_FAILED,
                 new MessageConsumptionFailed($msg, $exception)
             );
 
-            return self::MSG_REJECT;
+            return false;
         }
     }
 }

--- a/tests/RabbitMQMessageConsumerTest.php
+++ b/tests/RabbitMQMessageConsumerTest.php
@@ -29,7 +29,7 @@ class RabbitMQMessageConsumerTest extends \PHPUnit_Framework_TestCase
         $consumer = new RabbitMQMessageConsumer($serializedEnvelopeConsumer, $eventDispatcher);
 
         $result = $consumer->execute($message);
-        $this->assertSame(ConsumerInterface::MSG_ACK, $result);
+        $this->assertSame(true, $result);
     }
 
     /**
@@ -50,7 +50,7 @@ class RabbitMQMessageConsumerTest extends \PHPUnit_Framework_TestCase
         $consumer = new RabbitMQMessageConsumer($serializedEnvelopeConsumer, $eventDispatcher);
 
         $result = $consumer->execute($message);
-        $this->assertSame(ConsumerInterface::MSG_REJECT, $result);
+        $this->assertSame(false, $result);
     }
 
     private function newAMQPMessage($messageBody = '')


### PR DESCRIPTION
The OldSoundRabbitMqBundle consumers must return `false` in order to reject the message. Right now, we are using the `ConsumerInterface` constants that are not to be used for that.
